### PR TITLE
Fix render for mobile devices.

### DIFF
--- a/Rails_app/app/views/layouts/application.html.erb
+++ b/Rails_app/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= full_title(yield(:title)) %>
   </title>
   <%= csrf_meta_tags %>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 </head>
@@ -59,7 +60,7 @@
       </div>
 
       <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
-  
+
         <div class="container">
           <% flash.each do |message_type, message| %>
             <div class="alert alert-<%= message_type %>"><%= message %></div>


### PR DESCRIPTION
Defaults to small viewport on mobile devices, collapsing the design.
Still need to fix the menu though, so that ~~search and~~ the product
category menu moves to the hamburger menu.

![Screenshot](https://scontent-arn2-1.xx.fbcdn.net/v/t34.0-12/15403253_10154472743231747_335878168_n.png?oh=6cc2b8c63de0fa5534a4bfba1b628ccd&oe=5869A992)